### PR TITLE
Reset new song properties on transition

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -118,6 +118,8 @@ App.ArtistSongsRoute = Ember.Route.extend({
   setupController: function(controller, model) {
     this._super(controller, model);
     controller.set('artist', this.modelFor('artist'));
+    controller.set('newSong', '');
+    controller.set('songCreationStarted', false);
   },
 
   actions: {


### PR DESCRIPTION
Use ArtistsSongsRoute to properly setup controller between transitions once song creation has been initiated.  If someone has clicked the "Why don't you create one?" link, and then transitions to another artist without any songs defined they will be prompted with the no songs dialogue instead of the new song form.  Also if a song name is entered, but not submitted, it will be cleared from the form.